### PR TITLE
Fix/enforce uuids for database name creation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "cf-service-broker-dashboard"]
-	path = cf-service-broker-dashboard
-	url = git@github.com:evoila/cf-service-broker-dashboard.git
 [submodule "osb-dashboard"]
 	path = osb-dashboard
 	url = git@github.com:evoila/cf-service-broker-dashboard.git

--- a/osb-service/src/main/java/de/evoila/cf/broker/custom/cassandra/CassandraUtils.java
+++ b/osb-service/src/main/java/de/evoila/cf/broker/custom/cassandra/CassandraUtils.java
@@ -1,17 +1,19 @@
 package de.evoila.cf.broker.custom.cassandra;
 
+import de.evoila.cf.broker.util.UuidUtils;
+
 /**
- * @author Johannes Hiemer.
+ * @author Johannes Hiemer, Johannes Strauß.
  */
 public class CassandraUtils {
 
     public static String dbName(String uuid) {
-        if (uuid != null && uuid.length() > 15)
-            return "d" + uuid.replace("-", "")
-                    .substring(0, 15)
-                    .toLowerCase();
-        else
-            return null;
-    }
+        if (!UuidUtils.isValidUUID(uuid)) {
+            throw new IllegalArgumentException("Please use valid UUIDs to create Cassandra database names!");
+        }
 
+        return "d" + uuid.replace("-", "")
+                .substring(0, 15)
+                .toLowerCase();
+    }
 }

--- a/osb-service/src/test/java/de/evoila/cf/broker/custom/cassandra/CassandraUtilsTest.java
+++ b/osb-service/src/test/java/de/evoila/cf/broker/custom/cassandra/CassandraUtilsTest.java
@@ -1,0 +1,30 @@
+package de.evoila.cf.broker.custom.cassandra;
+
+import org.junit.jupiter.api.Test;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author Johannes Strauß
+ **/
+class CassandraUtilsTest {
+
+    private String validUuid = "8dc7110d-30b2-4553-8867-1777f8808cbf";
+
+    @Test
+    void throwsIllegalArgumentException() {
+        String[] illegalInput = {null, "Invalid"};
+
+        for (String uuid : illegalInput) {
+            assertThrows(IllegalArgumentException.class, () -> CassandraUtils.dbName(uuid));
+        }
+    }
+
+    @Test
+    void returnsAlteredStringWhenGivenValidInput() {
+        String result = CassandraUtils.dbName(validUuid);
+        assertTrue(Pattern.matches("d[a-z0-9]{1,15}", result));
+    }
+}


### PR DESCRIPTION
To create a database the instance id is being used to create a database name. When not entering a valid UUID unexpected behaviour can occur. Therefore we should enforce UUIDs.